### PR TITLE
Fixed bug which mutated URLs with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can fulfill any prerequisites such as login form submittion so that a login 
 
 ## Broad crawling
 
-Althogh the module is only well tested for "focused crawl" at this point,
+Although the module is only well tested for "focused crawl" at this point,
 you can also use it for endless crawling by taking special care of memory usage including;
 
 * Restrict queue size by yourself.

--- a/lib/WWW/Crawler/Mojo/ScraperUtil.pm
+++ b/lib/WWW/Crawler/Mojo/ScraperUtil.pm
@@ -146,7 +146,6 @@ sub reduce_html_handlers {
 
 sub resolve_href {
   my ($base, $href) = @_;
-  $href =~ s{\s}{}g;
   $href = ref $href ? $href : Mojo::URL->new($href);
   $base = ref $base ? $base : Mojo::URL->new($base);
   my $abs        = $href->fragment(undef)->to_abs($base);


### PR DESCRIPTION
Previously whitespace was being stripped from scrapped URL's. 
For example this page: 
www.auslan.org.au/dictionary/words/work%20out-1.html

Has links to several other pages with non-escaped spaces:
document.querySelectorAll('#signinfo .pull-right a')

When a new Mojo::URL object is made from it, Mojo is smart enough to escape those spaces correctly. But by stripping those spaces before handing it to Mojo, as it was doing previously, an invalid url is generated since workout-2.html (rather than work%20out-2.html) doesn't exist.

I'm pretty new to pull requests so let me know if I've done anything wrong! Cheers 👍 