### PR TITLE
Allow 'req' to mark URLs to skip

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for WWW-Crawler-Mojo
 
+0.22 0000/00/00
+  - Allow 'req' to mark URLs to skip
+
 0.21 2017/01/17
   - Fix a bug where url including white spaces haven't been treated propery.
   - Form submition now includes passwords and dates.

--- a/lib/WWW/Crawler/Mojo.pm
+++ b/lib/WWW/Crawler/Mojo.pm
@@ -85,6 +85,8 @@ sub process_job {
 
   $self->emit('req', $job, $tx->req);
 
+  return if $job->closed;
+
   $self->ua->start(
     $tx => sub {
       my ($ua, $tx) = @_;
@@ -315,6 +317,9 @@ arguments.
 
     $bot->on(req => sub {
         my ($bot, $job, $req) = @_;
+
+        # skip this URL if it matches
+        $job->closed if $job->url =~ m/something/;
 
         # DO NOTHING
     });


### PR DESCRIPTION
There are times when an URL is added to the queue that you know
don't need to be checked, so allow 'req' to mark them for ignoring